### PR TITLE
added entities based on db

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ APP_SECRET=
 # IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/travelshare-web?serverVersion=8.0.32&charset=utf8mb4"
+DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/travelshare?serverVersion=8.0.32&charset=utf8mb4"
 # DATABASE_URL="mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=10.11.2-MariaDB&charset=utf8mb4"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=16&charset=utf8"
 ###< doctrine/doctrine-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "doctrine/dbal": "^3.9.4",
-        "doctrine/doctrine-bundle": "^2.13.2",
+        "doctrine/doctrine-bundle": "^2.13",
         "doctrine/doctrine-migrations-bundle": "^3.4.1",
         "doctrine/orm": "^3.3.2",
         "phpdocumentor/reflection-docblock": "^5.6.1",
@@ -100,7 +100,7 @@
         "symfony/browser-kit": "7.2.*",
         "symfony/css-selector": "7.2.*",
         "symfony/debug-bundle": "7.2.*",
-        "symfony/maker-bundle": "^1.62.1",
+        "symfony/maker-bundle": "^1.62",
         "symfony/phpunit-bridge": "^7.2",
         "symfony/stopwatch": "7.2.*",
         "symfony/web-profiler-bundle": "7.2.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f374e52b4dad43eba4c401297efc92fb",
+    "content-hash": "d0f6e184456462bec975cbef99ba4f0f",
     "packages": [
         {
             "name": "doctrine/cache",

--- a/src/Entity/Chambres.php
+++ b/src/Entity/Chambres.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ChambresRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'chambres')]
+#[ORM\Index(name: 'fk_hotel_id', columns: ['hotel_id'])]
+#[ORM\Entity(repositoryClass: ChambresRepository::class)]
+class Chambres
+{
+    #[ORM\Column(name: "chambre_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $chambreId = null;
+
+    #[ORM\Column(name: "hotel_id")]
+    private ?int $hotelId = null;
+
+    #[ORM\Column(name: "numero_chambre", length: 255)]
+    private ?string $numeroChambre = null;
+
+    #[ORM\Column(name: "type_enu", type: Types::STRING)]
+    private ?string $typeEnu = null;
+
+    #[ORM\Column(name: "prix_par_nuit", type: Types::DECIMAL, precision: 10, scale: 0)]
+    private ?string $prixParNuit = null;
+
+    #[ORM\Column(name: "disponible")]
+    private ?int $disponible = null;
+
+    public function getChambreId(): ?int
+    {
+        return $this->chambreId;
+    }
+
+    public function getHotelId(): ?int
+    {
+        return $this->hotelId;
+    }
+
+    public function setHotelId(int $hotelId): static
+    {
+        $this->hotelId = $hotelId;
+
+        return $this;
+    }
+
+    public function getNumeroChambre(): ?string
+    {
+        return $this->numeroChambre;
+    }
+
+    public function setNumeroChambre(string $numeroChambre): static
+    {
+        $this->numeroChambre = $numeroChambre;
+
+        return $this;
+    }
+
+    public function getTypeEnu(): ?string
+    {
+        return $this->typeEnu;
+    }
+
+    public function setTypeEnu(string $typeEnu): static
+    {
+        $this->typeEnu = $typeEnu;
+
+        return $this;
+    }
+
+    public function getPrixParNuit(): ?string
+    {
+        return $this->prixParNuit;
+    }
+
+    public function setPrixParNuit(string $prixParNuit): static
+    {
+        $this->prixParNuit = $prixParNuit;
+
+        return $this;
+    }
+
+    public function getDisponible(): ?int
+    {
+        return $this->disponible;
+    }
+
+    public function setDisponible(int $disponible): static
+    {
+        $this->disponible = $disponible;
+
+        return $this;
+    }
+}

--- a/src/Entity/Comments.php
+++ b/src/Entity/Comments.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\CommentsRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'comments')]
+#[ORM\Index(name: 'fk_commenter_id', columns: ['commenter_id'])]
+#[ORM\Index(name: 'fk_comment_post_id', columns: ['post_id'])]
+#[ORM\Entity(repositoryClass: CommentsRepository::class)]
+class Comments
+{
+    #[ORM\Column(name: "comment_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $commentId = null;
+
+    #[ORM\Column(name: "post_id")]
+    private ?int $postId = null;
+
+    #[ORM\Column(name: "commenter_id")]
+    private ?int $commenterId = null;
+
+    #[ORM\Column(name: "comment", length: 255)]
+    private ?string $comment = null;
+
+    #[ORM\Column(name: "commented_at", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $commentedAt = null;
+
+    #[ORM\Column(name: "updated_at", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $updatedAt = null;
+
+    public function getCommentId(): ?int
+    {
+        return $this->commentId;
+    }
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
+
+    public function setPostId(int $postId): static
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getCommenterId(): ?int
+    {
+        return $this->commenterId;
+    }
+
+    public function setCommenterId(int $commenterId): static
+    {
+        $this->commenterId = $commenterId;
+
+        return $this;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(string $comment): static
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+
+    public function getCommentedAt(): ?\DateTimeInterface
+    {
+        return $this->commentedAt;
+    }
+
+    public function setCommentedAt(\DateTimeInterface $commentedAt): static
+    {
+        $this->commentedAt = $commentedAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): static
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+}

--- a/src/Entity/Excursions.php
+++ b/src/Entity/Excursions.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ExcursionsRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'excursions')]
+#[ORM\Index(name: 'fk_id_guide', columns: ['guide_id'])]
+#[ORM\Entity(repositoryClass: ExcursionsRepository::class)]
+class Excursions
+{
+    #[ORM\Column(name: "excursion_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $excursionId = null;
+
+    #[ORM\Column(name: "guide_id")]
+    private ?int $guideId = null;
+
+    #[ORM\Column(name: "title", length: 50)]
+    private ?string $title = null;
+
+    #[ORM\Column(name: "description", length: 255)]
+    private ?string $description = null;
+
+    #[ORM\Column(name: "date_excursion", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateExcursion = null;
+
+    #[ORM\Column(name: "date_fin", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateFin = null;
+
+    #[ORM\Column(name: "image", type: Types::BLOB)]
+    private $image = null;
+
+    #[ORM\Column(name: "prix")]
+    private ?float $prix = null;
+
+    public function getExcursionId(): ?int
+    {
+        return $this->excursionId;
+    }
+
+    public function getGuideId(): ?int
+    {
+        return $this->guideId;
+    }
+
+    public function setGuideId(int $guideId): static
+    {
+        $this->guideId = $guideId;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getDateExcursion(): ?\DateTimeInterface
+    {
+        return $this->dateExcursion;
+    }
+
+    public function setDateExcursion(\DateTimeInterface $dateExcursion): static
+    {
+        $this->dateExcursion = $dateExcursion;
+
+        return $this;
+    }
+
+    public function getDateFin(): ?\DateTimeInterface
+    {
+        return $this->dateFin;
+    }
+
+    public function setDateFin(\DateTimeInterface $dateFin): static
+    {
+        $this->dateFin = $dateFin;
+
+        return $this;
+    }
+
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    public function setImage($image): static
+    {
+        $this->image = $image;
+
+        return $this;
+    }
+
+    public function getPrix(): ?float
+    {
+        return $this->prix;
+    }
+
+    public function setPrix(float $prix): static
+    {
+        $this->prix = $prix;
+
+        return $this;
+    }
+}

--- a/src/Entity/FlaggedContent.php
+++ b/src/Entity/FlaggedContent.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\FlaggedContentRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'flagged_content')]
+#[ORM\Index(name: 'fk_flagger_id', columns: ['flagger_id'])]
+#[ORM\Entity(repositoryClass: FlaggedContentRepository::class)]
+class FlaggedContent
+{
+    #[ORM\Column(name: "post_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "NONE")]
+    private ?int $postId = null;
+
+    #[ORM\Column(name: "flagger_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "NONE")]
+    private ?int $flaggerId = null;
+
+    #[ORM\Column(name: "flagged_at", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $flaggedAt = null;
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
+
+    public function setPostId(int $postId): static
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getFlaggerId(): ?int
+    {
+        return $this->flaggerId;
+    }
+
+    public function setFlaggerId(int $flaggerId): static
+    {
+        $this->flaggerId = $flaggerId;
+
+        return $this;
+    }
+
+    public function getFlaggedAt(): ?\DateTimeInterface
+    {
+        return $this->flaggedAt;
+    }
+
+    public function setFlaggedAt(\DateTimeInterface $flaggedAt): static
+    {
+        $this->flaggedAt = $flaggedAt;
+
+        return $this;
+    }
+}

--- a/src/Entity/Guides.php
+++ b/src/Entity/Guides.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\GuidesRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'guides')]
+#[ORM\Entity(repositoryClass: GuidesRepository::class)]
+class Guides
+{
+    #[ORM\Column(name: "guide_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $guideId = null;
+
+    #[ORM\Column(name: "name", length: 50)]
+    private ?string $name = null;
+
+    #[ORM\Column(name: "last_name", length: 50)]
+    private ?string $lastName = null;
+
+    #[ORM\Column(name: "email", length: 50)]
+    private ?string $email = null;
+
+    #[ORM\Column(name: "phone_num", length: 50)]
+    private ?string $phoneNum = null;
+
+    #[ORM\Column(name: "language", length: 50)]
+    private ?string $language = null;
+
+    #[ORM\Column(name: "experience")]
+    private ?int $experience = null;
+
+    public function getGuideId(): ?int
+    {
+        return $this->guideId;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): static
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): static
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getPhoneNum(): ?string
+    {
+        return $this->phoneNum;
+    }
+
+    public function setPhoneNum(string $phoneNum): static
+    {
+        $this->phoneNum = $phoneNum;
+
+        return $this;
+    }
+
+    public function getLanguage(): ?string
+    {
+        return $this->language;
+    }
+
+    public function setLanguage(string $language): static
+    {
+        $this->language = $language;
+
+        return $this;
+    }
+
+    public function getExperience(): ?int
+    {
+        return $this->experience;
+    }
+
+    public function setExperience(int $experience): static
+    {
+        $this->experience = $experience;
+
+        return $this;
+    }
+}

--- a/src/Entity/Hotels.php
+++ b/src/Entity/Hotels.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\HotelsRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'hotels')]
+#[ORM\Entity(repositoryClass: HotelsRepository::class)]
+class Hotels
+{
+    #[ORM\Column(name: "hotel_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $hotelId = null;
+
+    #[ORM\Column(name: "nom", length: 255)]
+    private ?string $nom = null;
+
+    #[ORM\Column(name: "adress", type: Types::TEXT, nullable: true)]
+    private ?string $adress = null;
+
+    #[ORM\Column(name: "telephone", length: 255, nullable: true)]
+    private ?string $telephone = null;
+
+    #[ORM\Column(name: "capacite_totale")]
+    private ?int $capaciteTotale = null;
+
+    #[ORM\Column(name: "image_h", type: Types::BLOB)]
+    private $imageH = null;
+
+    public function getHotelId(): ?int
+    {
+        return $this->hotelId;
+    }
+
+    public function getNom(): ?string
+    {
+        return $this->nom;
+    }
+
+    public function setNom(string $nom): static
+    {
+        $this->nom = $nom;
+
+        return $this;
+    }
+
+    public function getAdress(): ?string
+    {
+        return $this->adress;
+    }
+
+    public function setAdress(?string $adress): static
+    {
+        $this->adress = $adress;
+
+        return $this;
+    }
+
+    public function getTelephone(): ?string
+    {
+        return $this->telephone;
+    }
+
+    public function setTelephone(?string $telephone): static
+    {
+        $this->telephone = $telephone;
+
+        return $this;
+    }
+
+    public function getCapaciteTotale(): ?int
+    {
+        return $this->capaciteTotale;
+    }
+
+    public function setCapaciteTotale(int $capaciteTotale): static
+    {
+        $this->capaciteTotale = $capaciteTotale;
+
+        return $this;
+    }
+
+    public function getImageH()
+    {
+        return $this->imageH;
+    }
+
+    public function setImageH($imageH): static
+    {
+        $this->imageH = $imageH;
+
+        return $this;
+    }
+}

--- a/src/Entity/Likes.php
+++ b/src/Entity/Likes.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\LikesRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'likes')]
+#[ORM\Index(name: 'liker_id', columns: ['liker_id'])]
+#[ORM\Entity(repositoryClass: LikesRepository::class)]
+class Likes
+{
+    #[ORM\Column(name: "post_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "NONE")]
+    private ?int $postId = null;
+
+    #[ORM\Column(name: "liker_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "NONE")]
+    private ?int $likerId = null;
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
+
+    public function setPostId(int $postId): static
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getLikerId(): ?int
+    {
+        return $this->likerId;
+    }
+
+    public function setLikerId(int $likerId): static
+    {
+        $this->likerId = $likerId;
+
+        return $this;
+    }
+}

--- a/src/Entity/OffresVoyage.php
+++ b/src/Entity/OffresVoyage.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\OffresVoyageRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'offres_voyage')]
+#[ORM\Entity(repositoryClass: OffresVoyageRepository::class)]
+class OffresVoyage
+{
+    #[ORM\Column(name: "offres_voyage_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $offresVoyageId = null;
+
+    #[ORM\Column(name: "titre", length: 255)]
+    private ?string $titre = null;
+
+    #[ORM\Column(name: "destination", length: 255)]
+    private ?string $destination = null;
+
+    #[ORM\Column(name: "description", type: Types::TEXT, nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(name: "date_depart", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateDepart = null;
+
+    #[ORM\Column(name: "date_retour", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateRetour = null;
+
+    #[ORM\Column(name: "prix", type: Types::DECIMAL, precision: 10, scale: 0)]
+    private ?string $prix = null;
+
+    #[ORM\Column(name: "places_disponibles")]
+    private ?int $placesDisponibles = null;
+
+    public function getOffresVoyageId(): ?int
+    {
+        return $this->offresVoyageId;
+    }
+
+    public function getTitre(): ?string
+    {
+        return $this->titre;
+    }
+
+    public function setTitre(string $titre): static
+    {
+        $this->titre = $titre;
+
+        return $this;
+    }
+
+    public function getDestination(): ?string
+    {
+        return $this->destination;
+    }
+
+    public function setDestination(string $destination): static
+    {
+        $this->destination = $destination;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getDateDepart(): ?\DateTimeInterface
+    {
+        return $this->dateDepart;
+    }
+
+    public function setDateDepart(\DateTimeInterface $dateDepart): static
+    {
+        $this->dateDepart = $dateDepart;
+
+        return $this;
+    }
+
+    public function getDateRetour(): ?\DateTimeInterface
+    {
+        return $this->dateRetour;
+    }
+
+    public function setDateRetour(\DateTimeInterface $dateRetour): static
+    {
+        $this->dateRetour = $dateRetour;
+
+        return $this;
+    }
+
+    public function getPrix(): ?string
+    {
+        return $this->prix;
+    }
+
+    public function setPrix(string $prix): static
+    {
+        $this->prix = $prix;
+
+        return $this;
+    }
+
+    public function getPlacesDisponibles(): ?int
+    {
+        return $this->placesDisponibles;
+    }
+
+    public function setPlacesDisponibles(int $placesDisponibles): static
+    {
+        $this->placesDisponibles = $placesDisponibles;
+
+        return $this;
+    }
+}

--- a/src/Entity/Posts.php
+++ b/src/Entity/Posts.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\PostsRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'posts')]
+#[ORM\Index(name: 'fk_owner_id', columns: ['Owner_id'])]
+#[ORM\Entity(repositoryClass: PostsRepository::class)]
+class Posts
+{
+    #[ORM\Column(name: "Post_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $postId = null;
+
+    #[ORM\Column(name: "Owner_id")]
+    private ?int $ownerId = null;
+
+    #[ORM\Column(name: "created_at", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $createdAt = null;
+
+    #[ORM\Column(name: "updated_at", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $updatedAt = null;
+
+    #[ORM\Column(name: "text_content", length: 255)]
+    private ?string $textContent = null;
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
+
+    public function getOwnerId(): ?int
+    {
+        return $this->ownerId;
+    }
+
+    public function setOwnerId(int $ownerId): static
+    {
+        $this->ownerId = $ownerId;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): static
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): static
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    public function getTextContent(): ?string
+    {
+        return $this->textContent;
+    }
+
+    public function setTextContent(string $textContent): static
+    {
+        $this->textContent = $textContent;
+
+        return $this;
+    }
+}

--- a/src/Entity/Reclamations.php
+++ b/src/Entity/Reclamations.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ReclamationsRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'reclamations')]
+#[ORM\Index(name: 'fk_user_id', columns: ['user_id'])]
+#[ORM\Entity(repositoryClass: ReclamationsRepository::class)]
+class Reclamations
+{
+    #[ORM\Column(name: "reclamation_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $reclamationId = null;
+
+    #[ORM\Column(name: "user_id")]
+    private ?int $userId = null;
+
+    #[ORM\Column(name: "title", length: 50)]
+    private ?string $title = null;
+
+    #[ORM\Column(name: "description", length: 255)]
+    private ?string $description = null;
+
+    #[ORM\Column(name: "date_reclamation", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateReclamation = null;
+
+    #[ORM\Column(name: "etat", length: 20, nullable: true, options: ["default" => 'en cours'])]
+    private ?string $etat = 'en cours';
+
+    public function getReclamationId(): ?int
+    {
+        return $this->reclamationId;
+    }
+
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function setUserId(int $userId): static
+    {
+        $this->userId = $userId;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): static
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getDateReclamation(): ?\DateTimeInterface
+    {
+        return $this->dateReclamation;
+    }
+
+    public function setDateReclamation(\DateTimeInterface $dateReclamation): static
+    {
+        $this->dateReclamation = $dateReclamation;
+
+        return $this;
+    }
+
+    public function getEtat(): ?string
+    {
+        return $this->etat;
+    }
+
+    public function setEtat(?string $etat): static
+    {
+        $this->etat = $etat;
+
+        return $this;
+    }
+}

--- a/src/Entity/Reponses.php
+++ b/src/Entity/Reponses.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ReponsesRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'reponses')]
+#[ORM\Index(name: 'fk_reclamation_id', columns: ['reclamation_id'])]
+#[ORM\Entity(repositoryClass: ReponsesRepository::class)]
+class Reponses
+{
+    #[ORM\Column(name: "reponse_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $reponseId = null;
+
+    #[ORM\Column(name: "reclamation_id")]
+    private ?int $reclamationId = null;
+
+    #[ORM\Column(name: "contenu", length: 255)]
+    private ?string $contenu = null;
+
+    #[ORM\Column(name: "date_reponse", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateReponse = null;
+
+    public function getReponseId(): ?int
+    {
+        return $this->reponseId;
+    }
+
+    public function getReclamationId(): ?int
+    {
+        return $this->reclamationId;
+    }
+
+    public function setReclamationId(int $reclamationId): static
+    {
+        $this->reclamationId = $reclamationId;
+
+        return $this;
+    }
+
+    public function getContenu(): ?string
+    {
+        return $this->contenu;
+    }
+
+    public function setContenu(string $contenu): static
+    {
+        $this->contenu = $contenu;
+
+        return $this;
+    }
+
+    public function getDateReponse(): ?\DateTimeInterface
+    {
+        return $this->dateReponse;
+    }
+
+    public function setDateReponse(\DateTimeInterface $dateReponse): static
+    {
+        $this->dateReponse = $dateReponse;
+
+        return $this;
+    }
+}

--- a/src/Entity/ReservationHotel.php
+++ b/src/Entity/ReservationHotel.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ReservationHotelRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'reservation_hotel')]
+#[ORM\Index(name: 'fk_client_id', columns: ['client_id'])]
+#[ORM\Index(name: 'fk_chambre_id', columns: ['chambre_id'])]
+#[ORM\Entity(repositoryClass: ReservationHotelRepository::class)]
+class ReservationHotel
+{
+    #[ORM\Column(name: "reservation_hotel_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $reservationHotelId = null;
+
+    #[ORM\Column(name: "client_id")]
+    private ?int $clientId = null;
+
+    #[ORM\Column(name: "chambre_id")]
+    private ?int $chambreId = null;
+
+    #[ORM\Column(name: "date_debut", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateDebut = null;
+
+    #[ORM\Column(name: "date_fin", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateFin = null;
+
+    #[ORM\Column(name: "status_enu", type: Types::STRING)]
+    private ?string $statusEnu = null;
+
+    #[ORM\Column(name: "prix_totale")]
+    private ?int $prixTotale = null;
+
+    public function getReservationHotelId(): ?int
+    {
+        return $this->reservationHotelId;
+    }
+
+    public function getClientId(): ?int
+    {
+        return $this->clientId;
+    }
+
+    public function setClientId(int $clientId): static
+    {
+        $this->clientId = $clientId;
+
+        return $this;
+    }
+
+    public function getChambreId(): ?int
+    {
+        return $this->chambreId;
+    }
+
+    public function setChambreId(int $chambreId): static
+    {
+        $this->chambreId = $chambreId;
+
+        return $this;
+    }
+
+    public function getDateDebut(): ?\DateTimeInterface
+    {
+        return $this->dateDebut;
+    }
+
+    public function setDateDebut(\DateTimeInterface $dateDebut): static
+    {
+        $this->dateDebut = $dateDebut;
+
+        return $this;
+    }
+
+    public function getDateFin(): ?\DateTimeInterface
+    {
+        return $this->dateFin;
+    }
+
+    public function setDateFin(\DateTimeInterface $dateFin): static
+    {
+        $this->dateFin = $dateFin;
+
+        return $this;
+    }
+
+    public function getStatusEnu(): ?string
+    {
+        return $this->statusEnu;
+    }
+
+    public function setStatusEnu(string $statusEnu): static
+    {
+        $this->statusEnu = $statusEnu;
+
+        return $this;
+    }
+
+    public function getPrixTotale(): ?int
+    {
+        return $this->prixTotale;
+    }
+
+    public function setPrixTotale(int $prixTotale): static
+    {
+        $this->prixTotale = $prixTotale;
+
+        return $this;
+    }
+}

--- a/src/Entity/ReservationOffresVoyage.php
+++ b/src/Entity/ReservationOffresVoyage.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ReservationOffresVoyageRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'reservation_offres_voyage')]
+#[ORM\Index(name: 'fk_client', columns: ['client_id'])]
+#[ORM\Index(name: 'fk_offre_id', columns: ['offre_id'])]
+#[ORM\Entity(repositoryClass: ReservationOffresVoyageRepository::class)]
+class ReservationOffresVoyage
+{
+    #[ORM\Column(name: "reservation_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $reservationId = null;
+
+    #[ORM\Column(name: "client_id")]
+    private ?int $clientId = null;
+
+    #[ORM\Column(name: "offre_id")]
+    private ?int $offreId = null;
+
+    #[ORM\Column(name: "date_reserved", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateReserved = null;
+
+    #[ORM\Column(name: "status")]
+    private ?int $status = null;
+
+    #[ORM\Column(name: "nbr_place")]
+    private ?int $nbrPlace = null;
+
+    #[ORM\Column(name: "prix")]
+    private ?float $prix = null;
+
+    public function getReservationId(): ?int
+    {
+        return $this->reservationId;
+    }
+
+    public function getClientId(): ?int
+    {
+        return $this->clientId;
+    }
+
+    public function setClientId(int $clientId): static
+    {
+        $this->clientId = $clientId;
+
+        return $this;
+    }
+
+    public function getOffreId(): ?int
+    {
+        return $this->offreId;
+    }
+
+    public function setOffreId(int $offreId): static
+    {
+        $this->offreId = $offreId;
+
+        return $this;
+    }
+
+    public function getDateReserved(): ?\DateTimeInterface
+    {
+        return $this->dateReserved;
+    }
+
+    public function setDateReserved(\DateTimeInterface $dateReserved): static
+    {
+        $this->dateReserved = $dateReserved;
+
+        return $this;
+    }
+
+    public function getStatus(): ?int
+    {
+        return $this->status;
+    }
+
+    public function setStatus(int $status): static
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getNbrPlace(): ?int
+    {
+        return $this->nbrPlace;
+    }
+
+    public function setNbrPlace(int $nbrPlace): static
+    {
+        $this->nbrPlace = $nbrPlace;
+
+        return $this;
+    }
+
+    public function getPrix(): ?float
+    {
+        return $this->prix;
+    }
+
+    public function setPrix(float $prix): static
+    {
+        $this->prix = $prix;
+
+        return $this;
+    }
+}

--- a/src/Entity/ReservationPacks.php
+++ b/src/Entity/ReservationPacks.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\ReservationPacksRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'reservation_packs')]
+#[ORM\Index(name: 'fk_packs_client_id', columns: ['client_id'])]
+#[ORM\Index(name: 'fk_pack_id', columns: ['pack_id'])]
+#[ORM\Entity(repositoryClass: ReservationPacksRepository::class)]
+class ReservationPacks
+{
+    #[ORM\Column(name: "reservation_packs_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $reservationPacksId = null;
+
+    #[ORM\Column(name: "client_id")]
+    private ?int $clientId = null;
+
+    #[ORM\Column(name: "pack_id")]
+    private ?int $packId = null;
+
+    #[ORM\Column(name: "date_reservation", type: Types::DATE_MUTABLE)]
+    private ?\DateTimeInterface $dateReservation = null;
+
+    #[ORM\Column(name: "statut", type: Types::STRING)]
+    private ?string $statut = null;
+
+    #[ORM\Column(name: "prix_total", type: Types::DECIMAL, precision: 10, scale: 0)]
+    private ?string $prixTotal = null;
+
+    public function getReservationPacksId(): ?int
+    {
+        return $this->reservationPacksId;
+    }
+
+    public function getClientId(): ?int
+    {
+        return $this->clientId;
+    }
+
+    public function setClientId(int $clientId): static
+    {
+        $this->clientId = $clientId;
+
+        return $this;
+    }
+
+    public function getPackId(): ?int
+    {
+        return $this->packId;
+    }
+
+    public function setPackId(int $packId): static
+    {
+        $this->packId = $packId;
+
+        return $this;
+    }
+
+    public function getDateReservation(): ?\DateTimeInterface
+    {
+        return $this->dateReservation;
+    }
+
+    public function setDateReservation(\DateTimeInterface $dateReservation): static
+    {
+        $this->dateReservation = $dateReservation;
+
+        return $this;
+    }
+
+    public function getStatut(): ?string
+    {
+        return $this->statut;
+    }
+
+    public function setStatut(string $statut): static
+    {
+        $this->statut = $statut;
+
+        return $this;
+    }
+
+    public function getPrixTotal(): ?string
+    {
+        return $this->prixTotal;
+    }
+
+    public function setPrixTotal(string $prixTotal): static
+    {
+        $this->prixTotal = $prixTotal;
+
+        return $this;
+    }
+}

--- a/src/Entity/Users.php
+++ b/src/Entity/Users.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\UsersRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Table(name: 'users')]
+#[ORM\Entity(repositoryClass: UsersRepository::class)]
+class Users
+{
+    #[ORM\Column(name: "user_id")]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "IDENTITY")]
+    private ?int $userId = null;
+
+    #[ORM\Column(name: "name", length: 50)]
+    private ?string $name = null;
+
+    #[ORM\Column(name: "last_name", length: 50)]
+    private ?string $lastName = null;
+
+    #[ORM\Column(name: "email", length: 50)]
+    private ?string $email = null;
+
+    #[ORM\Column(name: "password", length: 255)]
+    private ?string $password = null;
+
+    #[ORM\Column(name: "phone_num")]
+    private ?int $phoneNum = null;
+
+    #[ORM\Column(name: "address", length: 150)]
+    private ?string $address = null;
+
+    #[ORM\Column(name: "role", nullable: true, options: ["default" => 0])]
+    private ?int $role = 0;
+
+    #[ORM\Column(name: "photo", type: Types::BLOB, nullable: true)]
+    private $photo = null;
+
+    #[ORM\Column(name: "compte", nullable: true, options: ["default" => 0])]
+    private ?int $compte = 0;
+
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): static
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): static
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(string $password): static
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function getPhoneNum(): ?int
+    {
+        return $this->phoneNum;
+    }
+
+    public function setPhoneNum(int $phoneNum): static
+    {
+        $this->phoneNum = $phoneNum;
+
+        return $this;
+    }
+
+    public function getAddress(): ?string
+    {
+        return $this->address;
+    }
+
+    public function setAddress(string $address): static
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    public function getRole(): ?int
+    {
+        return $this->role;
+    }
+
+    public function setRole(?int $role): static
+    {
+        $this->role = $role;
+
+        return $this;
+    }
+
+    public function getPhoto()
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto($photo): static
+    {
+        $this->photo = $photo;
+
+        return $this;
+    }
+
+    public function getCompte(): ?int
+    {
+        return $this->compte;
+    }
+
+    public function setCompte(?int $compte): static
+    {
+        $this->compte = $compte;
+
+        return $this;
+    }
+}

--- a/src/Repository/ChambresRepository.php
+++ b/src/Repository/ChambresRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Chambres;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Chambres>
+ *
+ * @method Chambres|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Chambres|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Chambres[]    findAll()
+ * @method Chambres[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ChambresRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Chambres::class);
+    }
+
+//    /**
+//     * @return Chambres[] Returns an array of Chambres objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Chambres
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/CommentsRepository.php
+++ b/src/Repository/CommentsRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Comments;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Comments>
+ *
+ * @method Comments|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Comments|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Comments[]    findAll()
+ * @method Comments[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class CommentsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Comments::class);
+    }
+
+//    /**
+//     * @return Comments[] Returns an array of Comments objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Comments
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/ExcursionsRepository.php
+++ b/src/Repository/ExcursionsRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Excursions;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Excursions>
+ *
+ * @method Excursions|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Excursions|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Excursions[]    findAll()
+ * @method Excursions[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ExcursionsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Excursions::class);
+    }
+
+//    /**
+//     * @return Excursions[] Returns an array of Excursions objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Excursions
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/FlaggedContentRepository.php
+++ b/src/Repository/FlaggedContentRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\FlaggedContent;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<FlaggedContent>
+ *
+ * @method FlaggedContent|null find($id, $lockMode = null, $lockVersion = null)
+ * @method FlaggedContent|null findOneBy(array $criteria, array $orderBy = null)
+ * @method FlaggedContent[]    findAll()
+ * @method FlaggedContent[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class FlaggedContentRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, FlaggedContent::class);
+    }
+
+//    /**
+//     * @return FlaggedContent[] Returns an array of FlaggedContent objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?FlaggedContent
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/GuidesRepository.php
+++ b/src/Repository/GuidesRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Guides;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Guides>
+ *
+ * @method Guides|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Guides|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Guides[]    findAll()
+ * @method Guides[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class GuidesRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Guides::class);
+    }
+
+//    /**
+//     * @return Guides[] Returns an array of Guides objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Guides
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/HotelsRepository.php
+++ b/src/Repository/HotelsRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Hotels;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Hotels>
+ *
+ * @method Hotels|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Hotels|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Hotels[]    findAll()
+ * @method Hotels[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class HotelsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Hotels::class);
+    }
+
+//    /**
+//     * @return Hotels[] Returns an array of Hotels objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Hotels
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/LikesRepository.php
+++ b/src/Repository/LikesRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Likes;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Likes>
+ *
+ * @method Likes|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Likes|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Likes[]    findAll()
+ * @method Likes[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class LikesRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Likes::class);
+    }
+
+//    /**
+//     * @return Likes[] Returns an array of Likes objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Likes
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/OffresVoyageRepository.php
+++ b/src/Repository/OffresVoyageRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\OffresVoyage;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<OffresVoyage>
+ *
+ * @method OffresVoyage|null find($id, $lockMode = null, $lockVersion = null)
+ * @method OffresVoyage|null findOneBy(array $criteria, array $orderBy = null)
+ * @method OffresVoyage[]    findAll()
+ * @method OffresVoyage[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class OffresVoyageRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, OffresVoyage::class);
+    }
+
+//    /**
+//     * @return OffresVoyage[] Returns an array of OffresVoyage objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?OffresVoyage
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/PostsRepository.php
+++ b/src/Repository/PostsRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Posts;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Posts>
+ *
+ * @method Posts|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Posts|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Posts[]    findAll()
+ * @method Posts[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class PostsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Posts::class);
+    }
+
+//    /**
+//     * @return Posts[] Returns an array of Posts objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Posts
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/ReclamationsRepository.php
+++ b/src/Repository/ReclamationsRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Reclamations;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Reclamations>
+ *
+ * @method Reclamations|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Reclamations|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Reclamations[]    findAll()
+ * @method Reclamations[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ReclamationsRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Reclamations::class);
+    }
+
+//    /**
+//     * @return Reclamations[] Returns an array of Reclamations objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Reclamations
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/ReponsesRepository.php
+++ b/src/Repository/ReponsesRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Reponses;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Reponses>
+ *
+ * @method Reponses|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Reponses|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Reponses[]    findAll()
+ * @method Reponses[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ReponsesRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Reponses::class);
+    }
+
+//    /**
+//     * @return Reponses[] Returns an array of Reponses objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Reponses
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/ReservationHotelRepository.php
+++ b/src/Repository/ReservationHotelRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ReservationHotel;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReservationHotel>
+ *
+ * @method ReservationHotel|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ReservationHotel|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ReservationHotel[]    findAll()
+ * @method ReservationHotel[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ReservationHotelRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReservationHotel::class);
+    }
+
+//    /**
+//     * @return ReservationHotel[] Returns an array of ReservationHotel objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?ReservationHotel
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/ReservationOffresVoyageRepository.php
+++ b/src/Repository/ReservationOffresVoyageRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ReservationOffresVoyage;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReservationOffresVoyage>
+ *
+ * @method ReservationOffresVoyage|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ReservationOffresVoyage|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ReservationOffresVoyage[]    findAll()
+ * @method ReservationOffresVoyage[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ReservationOffresVoyageRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReservationOffresVoyage::class);
+    }
+
+//    /**
+//     * @return ReservationOffresVoyage[] Returns an array of ReservationOffresVoyage objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?ReservationOffresVoyage
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/ReservationPacksRepository.php
+++ b/src/Repository/ReservationPacksRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\ReservationPacks;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<ReservationPacks>
+ *
+ * @method ReservationPacks|null find($id, $lockMode = null, $lockVersion = null)
+ * @method ReservationPacks|null findOneBy(array $criteria, array $orderBy = null)
+ * @method ReservationPacks[]    findAll()
+ * @method ReservationPacks[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class ReservationPacksRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, ReservationPacks::class);
+    }
+
+//    /**
+//     * @return ReservationPacks[] Returns an array of ReservationPacks objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?ReservationPacks
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/src/Repository/UsersRepository.php
+++ b/src/Repository/UsersRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Users;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Users>
+ *
+ * @method Users|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Users|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Users[]    findAll()
+ * @method Users[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UsersRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Users::class);
+    }
+
+//    /**
+//     * @return Users[] Returns an array of Users objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('a.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Users
+//    {
+//        return $this->createQueryBuilder('a')
+//            ->andWhere('a.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}


### PR DESCRIPTION
### TL;DR

Added entity classes and repositories for the TravelShare application database schema.

### What changed?

- Updated database name in `.env.example` from `travelshare-web` to `travelshare`
- Relaxed version constraints for Doctrine and Symfony Maker bundles
- Created 15 entity classes with their corresponding repositories:
  - `Users` - User account management
  - `Posts` - Social media content
  - `Comments` - Post comments
  - `Likes` - Post likes tracking
  - `FlaggedContent` - Content moderation
  - `Hotels` - Hotel information
  - `Chambres` - Hotel rooms
  - `ReservationHotel` - Hotel bookings
  - `OffresVoyage` - Travel offers
  - `ReservationOffresVoyage` - Travel offer bookings
  - `ReservationPacks` - Package bookings
  - `Guides` - Tour guide information
  - `Excursions` - Guided tours
  - `Reclamations` - User complaints
  - `Reponses` - Responses to complaints

### Why make this change?

This change establishes the core data model for the TravelShare application, mapping the database schema to Doctrine entities. The entities represent the main business objects needed for the travel sharing platform, including user management, social features, hotel bookings, travel offers, and customer service components.