### PR TITLE
fixed typo

### DIFF
--- a/templates/forum/index.html.twig
+++ b/templates/forum/index.html.twig
@@ -629,7 +629,7 @@
 		if(!text) return false;
 		if (text.length < 15) return false;
 		if (text.length > 255) return false;
-		const cachedResult = sessionStorage.getItem(`profanity_${bota(text)}`);
+		const cachedResult = sessionStorage.getItem(`profanity_${btoa(text)}`);
 		if (cachedResult !== null) return JSON.parse(cachedResult);
 		try {
 			const controller = new AbortController();
@@ -651,7 +651,7 @@
 			}
 
 			const result = await response.json();
-			sessionStorage.setItem(`profanity_${bota(text)}`, JSON.stringify(result.isProfanity));
+			sessionStorage.setItem(`profanity_${btoa(text)}`, JSON.stringify(result.isProfanity));
 			return result.isProfanity;
 		} catch (error) {
 			console.error('Error validating profanity:', error);


### PR DESCRIPTION
### TL;DR

Fixed a typo in the profanity check function where `bota()` was incorrectly used instead of `btoa()`.

### What changed?

Corrected two instances where the function `bota()` was incorrectly used for Base64 encoding in the profanity check caching mechanism. The correct function name is `btoa()` (binary to ASCII), which is used to encode strings to Base64.

### Why make this change?

The incorrect function name `bota()` would cause JavaScript errors when the profanity check function was called, preventing the caching mechanism from working properly. This fix ensures that text submissions are properly encoded when cached in the session storage, allowing the profanity check to function as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the forum's profanity validation, ensuring cached results are handled properly for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->