### PR TITLE
fixed base import

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -30,10 +30,8 @@
 
 		<link href="{{ asset('css/style.css') }}" rel="stylesheet" />
 
-		{% block stylesheets %} {{ encore_entry_link_tags('app') }} {% endblock %} {{ encore_entry_link_tags('app') }} {%
-            {{ encore_entry_link_tags('app') }}
-		block javascripts %} {{ encore_entry_script_tags('app') }} {% endblock %} {{ encore_entry_script_tags('app') }} {%
-		block css%} {% endblock%}
+		{% block stylesheets %} {{ encore_entry_link_tags('app') }} {% endblock %}
+		{% block javascripts %} {{ encore_entry_script_tags('app') }} {% endblock %}
 	</head>
 	<body class="min-vh-100">
 		<nav class="sticky-top">


### PR DESCRIPTION
### TL;DR

Removed duplicate Encore asset tags in base template

### What changed?

- Removed duplicate `encore_entry_link_tags('app')` that appeared twice in the template
- Removed duplicate `encore_entry_script_tags('app')` that appeared after the block definition
- Removed unnecessary `{% block css%} {% endblock%}` as it's redundant with the stylesheets block
- Fixed indentation and formatting in the head section

### Why make this change?

The duplicate asset tags were causing the same CSS and JavaScript files to be loaded multiple times, which is inefficient and could potentially cause conflicts or unexpected behavior. This change improves page load performance and removes redundant code.